### PR TITLE
add rules for variable names and refactor code

### DIFF
--- a/docs/docs/rules.md
+++ b/docs/docs/rules.md
@@ -1,0 +1,11 @@
+# Rules
+This document covers any rules that apply either to the entire codebase or multiple parts of the codebase. These rules mainly are naming conventions.
+
+1. When referencing an element that you would use inside the canvas it should be named a certain way to immediately understand whether the variable is referencing the HTML object or the elements' object to keep track of details.
+
+```
+let elemDetails; // Element's object
+let elem; // Element's HTML object
+let elemId; // The Element's id
+
+```

--- a/elemCreator.js
+++ b/elemCreator.js
@@ -4,38 +4,51 @@ const headings = ["h1", "h2", "h3", "h4", "h5", "h6"];
 const headingsConfig = {
     "h1": {
         "text": "Heading One",
-        "fontSize": "32"
+        "fontSize": "32px",
     },
     "h2": {
         "text": "Heading Two",
-        "fontSize": "24"
+        "fontSize": "24px",
     },
     "h3": {
         "text": "Heading Three",
-        "fontSize": "18.72"
+        "fontSize": "18.72px",
     },
     "h4": {
         "text": "Heading Four",
-        "fontSize": "16"
+        "fontSize": "16px",
     },
     "h5": {
         "text": "Heading Five",
-        "fontSize": "13.28"
+        "fontSize": "13.28px",
     },
     "h6": {
         "text": "Heading Six",
-        "fontSize": "10.72"
+        "fontSize": "10.72px",
     },
 }
 
 function createHeading (elemName, pageTarget) {
+    /**
+     * Initialises a heading element and creates its element class
+     * @return {Heading}
+     */
     let elem;
     elem = document.createElement(elemName);
     elem.innerHTML = headingsConfig[elemName]["text"];
-    return new Heading(elem, headingsConfig[elemName]["fontSize"], pageTarget);
+    elem.style.position = "absolute";
+    elem.style.color = "black";
+    elem.style.left = 0;
+    elem.style.top = 0;
+    elem.style.fontSize = headingsConfig[elemName]["fontSize"];
+    return new Heading(elem, pageTarget);
 }
 
 export function mapElemCreator (elemName, pageTarget) {
+    /**
+     * Finds the element initialiser 
+     * @return {Heading}
+     */
     if (headings.includes(elemName)) {
         return createHeading(elemName, pageTarget);
     }

--- a/elementsClasses.js
+++ b/elementsClasses.js
@@ -1,118 +1,75 @@
-const nav = document.getElementById("nav");
-const container = document.getElementById("container");
+import { setColor, setFontSize, setText, setX, setY, setPosition } from "./validators.js";
 
 const Element = {
     elem: '',
-    x: '',
-    y: '',
     page: '', // null if on canvas, otherwise page id
 }
 
 export class Heading {
-    constructor(elem, fontSize, page) {        
-        this.color = "black";
-        this.fontSize = fontSize;
+    constructor(elem, page) {        
         this.elem = elem;
-        this.text = elem.innerHTML;
-        this.x = 0;
-        this.y = 0;
-        this.position = "static";
         this.page = page;
     }
 
     updateMapper(key, value) {
         switch (key) {
             case "fontSize":
-                this.setFontSize = value;
+                setFontSize(this.elem, value);
                 break;
             case "color":
-                this.setColor = value;
+                setColor(this.elem, value);
                 break;
             case "text":
-                this.setText = value;
+                setText(this.elem, value);
                 break;
             case "x":
-                this.setX = value;
+                setX(this.elem, value);
                 break;
             case "y":
-                this.setY = value;
+                setY(this.elem, value);
                 break;
             case "position":
-                this.setPosition = value;
+                setPosition(this.elem, value);
                 break;
             case "page":
                 this.page = value;
+                break;
         }
     }
 
-    get getStyle() {
-        return "style='" + 
-        "color: " + this.color + ";" + 
-        "font-size: " + this.fontSize + ";" + 
-        "text-align: " + this.align + ";" + 
-        "position: " + this.position + ";" +
-        "top: " + this.y + ";" + 
-        "left: " + this.x + ";'";
-    }
-
-    get getItems() {
-        return {
-            "align": this.align,
-            "fontSize": this.fontSize,
-            "color": this.color,
-            "text": this.text
-        }
-    }
-
-    set setColor(color) {
-        let strCheck = this.elem.style.color = color;
-        
-        if (strCheck == "") {
-            this.elem.style.color = this.color;
-        } else {
-            this.color = color;
-        }
-    }
-
-    set setFontSize(fontSize) {
-        let strCheck = this.elem.style.fontSize = fontSize + "px";
-
-        if (strCheck == "") {
-            this.elem.style.fontSize = this.fontSize + "px";
-        } else {
-            this.fontSize = fontSize;
-        }
-    }
-
-    set setText(text) {
-        this.text = text;
-        this.elem.innerHTML = this.text;
-    }
-
-    set setX(value) {
-        value = parseInt(value);
-        this.x = value;
-        this.setPosition = "absolute";
-        this.elem.style.left = this.x + "px";
-    }
-
-    set setY(value) {
-        this.y = value;
-        this.setPosition = "absolute";
-        this.elem.style.top = this.y + "px";
-    }
-
-    set setPosition(value) {
-        value = value.toLowerCase();
-
-        let validArgs = ["static", "relative", "fixed", "absolute", "sticky"];
-        
-        for (let i = 0; i < validArgs.length; i++) {
-            if (value == validArgs[i]) {
-                this.position = value;
-                this.elem.style.position = value;        
-            }
-        }
+    getEditableProperties() {
+        return [
+            {
+                "system_name" : "fontSize",
+                "display_name": "Text Size (px)",
+                "value": this.elem.style.fontSize
+            }, 
+            {
+                "system_name": "color",
+                "display_name": "Colour",
+                "value": this.elem.style.color
+            },
+            {
+                "system_name": "text",
+                "display_name": "Text",
+                "value": this.elem.innerHTML
+            },
+            {
+                "system_name": "x",
+                "display_name": "x",
+                "value": this.elem.style.left
+            },
+            {
+                "system_name": "y",
+                "display_name": "y",
+                "value": this.elem.style.top
+            },
+            {
+                "system_name": "position",
+                "display_name": "Position",
+                "value": this.elem.style.position
+            },
+        ]
     }
 
     set setPage(value) {

--- a/validators.js
+++ b/validators.js
@@ -1,0 +1,42 @@
+export function setColor(elem, color) {
+    let strCheck = elem.style.color = color;
+    
+    if (strCheck == "") {
+        elem.style.color = color;
+    }
+}
+
+export function setFontSize(elem, fontSize) {
+    let strCheck = elem.style.fontSize = fontSize + "px";
+
+    if (strCheck == "") {
+        elem.style.fontSize = fontSize + "px";
+    }
+}
+
+export function setText(elem, text) {
+    elem.innerHTML = text;
+}
+
+export function setX(elem, value) {
+    value = parseInt(value);
+    setPosition = "absolute";
+    elem.style.left = value + "px";
+}
+
+export function setY(elem, value) {
+    setPosition = "absolute";
+    elem.style.top = value + "px";
+}
+
+export function setPosition(elem, value) {
+    value = value.toLowerCase();
+
+    let validArgs = ["static", "relative", "fixed", "absolute", "sticky"];
+    
+    for (let i = 0; i < validArgs.length; i++) {
+        if (value == validArgs[i]) {
+            elem.style.position = value;        
+        }
+    }
+}


### PR DESCRIPTION
closes #8 

Set rules for variables names available in docs/rules.md.

Also refactored the way element classes work. Now the element class just provides an interface to update and display editable values of an element and it keeps track of what page the element is on. Furthermore, the functions to update the elements properties now only update the element instead of a variable as well. 